### PR TITLE
Use OS default service names

### DIFF
--- a/manifests/pam/common.pp
+++ b/manifests/pam/common.pp
@@ -23,7 +23,7 @@ class googleauthenticator::pam::common {
   # Setup the three basic PAM modes
   googleauthenticator::pam::mode {
     'all-users':
-       service => $service;
+      service => $service;
 
     'root-only':
       succeed_if => 'uid > 0',

--- a/manifests/pam/common.pp
+++ b/manifests/pam/common.pp
@@ -10,6 +10,10 @@ class googleauthenticator::pam::common {
     /RedHat|CentOS/ => 'google-authenticator',
     default         => '',
   }
+  $service = $::operatingsystem ? {
+    /RedHat|CentOS/ => 'sshd',
+    default         => 'ssh',
+  }
 
   package {'pam-google-authenticator':
     name => $package,

--- a/manifests/pam/common.pp
+++ b/manifests/pam/common.pp
@@ -10,6 +10,7 @@ class googleauthenticator::pam::common {
     /RedHat|CentOS/ => 'google-authenticator',
     default         => '',
   }
+  
   $service = $::operatingsystem ? {
     /RedHat|CentOS/ => 'sshd',
     default         => 'ssh',
@@ -28,5 +29,7 @@ class googleauthenticator::pam::common {
 
     'systemwide-users':
       secret => "/etc/google-authenticator/\${USER}/google_authenticator";
+    
+    service => $service,
   }
 }

--- a/manifests/pam/common.pp
+++ b/manifests/pam/common.pp
@@ -22,14 +22,15 @@ class googleauthenticator::pam::common {
 
   # Setup the three basic PAM modes
   googleauthenticator::pam::mode {
-    'all-users':;
+    'all-users':
+       service => $service;
 
     'root-only':
-      succeed_if => 'uid > 0';
+      succeed_if => 'uid > 0',
+      service => $service;
 
     'systemwide-users':
-      secret => "/etc/google-authenticator/\${USER}/google_authenticator";
-    
-    service => $service,
+      secret => "/etc/google-authenticator/\${USER}/google_authenticator",
+      service => $service;
   }
 }

--- a/manifests/pam/mode.pp
+++ b/manifests/pam/mode.pp
@@ -31,6 +31,7 @@ define googleauthenticator::pam::mode(
   $nullok=false,
   $secret=false,
   $noskewadj=false,
+  $service='ssh',
 ) {
   file {"/etc/pam.d/google-authenticator-${name}":
     ensure  => $ensure,
@@ -38,6 +39,6 @@ define googleauthenticator::pam::mode(
     group   => 'root',
     mode    => '0644',
     content => template('googleauthenticator/pam-rule.erb'),
-    notify  => Service['ssh'],
+    notify  => Service[$service],
   }
 }

--- a/manifests/pam/redhat.pp
+++ b/manifests/pam/redhat.pp
@@ -36,7 +36,7 @@ define googleauthenticator::pam::redhat(
       augeas {"Purge existing google-authenticator from ${name}":
         context => "/files/etc/pam.d/${name}",
         changes => 'rm include[. =~ regexp("google-authenticator.*")]',
-        notify  => Service['ssh'],
+        notify  => Service['sshd'],
       }
     }
     default: { fail("Wrong ensure value ${ensure}") }

--- a/manifests/pam/redhat.pp
+++ b/manifests/pam/redhat.pp
@@ -29,7 +29,7 @@ define googleauthenticator::pam::redhat(
           "set include[. = ''] '${rule}'",
           ],
         require => File["/etc/pam.d/${rule}"],
-        notify  => Service['ssh'],
+        notify  => Service['sshd'],
       }
     }
     'absent': {


### PR DESCRIPTION
Rather than require the definition of "ssh" (or redefinition of service "sshd" as "ssh") on systems that do not use this as the default (i.e. RHEL and RH based systems like CentOS), make the service name a parameter defined by the OS in use. 

I have tested this against RHEL and CentOS. Functionality on Debian based systems is unchanged. 