### PR TITLE
fix GID & UID lookup

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -65,8 +65,8 @@ define googleauthenticator::user(
 
   file {$real_file:
     ensure  => $ensure,
-    owner   => $real_user,
-    group   => $real_group,
+    owner   => chomp(generate("/usr/bin/id", "-u", $real_user)),
+    group   => chomp(generate("/usr/bin/id", "-g", $real_user)),
     mode    => '0400',
     content => template('googleauthenticator/google-authenticator.erb'),
   }

--- a/manifests/user/systemwide.pp
+++ b/manifests/user/systemwide.pp
@@ -56,8 +56,8 @@ define googleauthenticator::user::systemwide(
 
   file {$user_directory:
     ensure  => $_ensure,
-    owner   => $real_user,
-    group   => $real_user,
+    owner   => chomp(generate("/usr/bin/id", "-u", $real_user)),
+    group   => chomp(generate("/usr/bin/id", "-g", $real_user)),
     mode    => '0700',
     # From googleauthenticator::user::systemwide::common
     require => File['/etc/google-authenticator'],


### PR DESCRIPTION
GID is not necessarily the same as UID - invoke '/usr/bin/id' to find out both.
This fixes the following two problems with (non-local) user accounts for me:

- directory owner & group:

```Googleauthenticator::User::Systemwide[my-user]/File[/etc/google-authenticator/my-user]/owner) change from root to my-user failed: Could not find user my-user```

- file owner & group:

```
Googleauthenticator::User::Systemwide[my-user]/Googleauthenticator::User[my-user]/File[/etc/google-authenticator/my-user/google_authenticator]/owner) change from root to my-user failed: Could not find user my-user
Googleauthenticator::User::Systemwide[my-user]/Googleauthenticator::User[my-user]/File[/etc/google-authenticator/my-user/google_authenticator]/group) change from root to my-user failed: Could not find group my-user
```