### PR TITLE
Set minimum version_requirement for Puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,11 @@
   "description": "Google Authenticator Module for Puppet",
   "project_page": "https://github.com/voxpupuli/puppet-googleauthenticator",
   "issues_url": "https://github.com/voxpupuli/puppet-googleauthenticator/issues",
-  "dependencies": [
-
+  "dependencies": [],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 < 5.0.0"
+    }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions