### PR TITLE
Do not show diff when modifying the secret file

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -64,10 +64,11 @@ define googleauthenticator::user(
   }
 
   file {$real_file:
-    ensure  => $ensure,
-    owner   => $real_user,
-    group   => $real_group,
-    mode    => '0400',
-    content => template('googleauthenticator/google-authenticator.erb'),
+    ensure    => $ensure,
+    owner     => $real_user,
+    group     => $real_group,
+    mode      => '0400',
+    content   => template('googleauthenticator/google-authenticator.erb'),
+    show_diff => false,
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
When email reports are enabled, changes to the key file result in
sending the OTP secret over email, largely defeating the purpose of
2-factor authentication. Setting show_diff=>false mitigates this
problem.

#### This Pull Request (PR) fixes the following issues
n/a