### PR TITLE
pam/redhat: use versioncmp function in conditional

### DIFF
--- a/manifests/pam/redhat.pp
+++ b/manifests/pam/redhat.pp
@@ -20,7 +20,7 @@ define googleauthenticator::pam::redhat (
 
   case $ensure {
     'present': {
-      if ($facts['os']['release']['major'] >= 7) {
+      if versioncmp($::facts['os']['release']['major'], '7') > 0 {
         augeas { "Add google-authenticator to ${name}":
           context => "/files/etc/pam.d/${name}",
           changes => [

--- a/manifests/pam/redhat.pp
+++ b/manifests/pam/redhat.pp
@@ -20,7 +20,7 @@ define googleauthenticator::pam::redhat (
 
   case $ensure {
     'present': {
-      if versioncmp($::facts['os']['release']['major'], '7') > 0 {
+      if versioncmp($facts['os']['release']['major'], '7') > 0 {
         augeas { "Add google-authenticator to ${name}":
           context => "/files/etc/pam.d/${name}",
           changes => [


### PR DESCRIPTION
#### Pull Request (PR) description

Use the built-in versioncmp function to check the version of the distribution, otherwise current Puppet installations fail with a type error (cannot compare String with Integer)

#### This Pull Request (PR) fixes the following issues
see above.
